### PR TITLE
fix(lib): all the props within Controls and ControlsNames interfaces should be required

### DIFF
--- a/projects/ngx-sub-form/src/lib/ngx-sub-form-utils.ts
+++ b/projects/ngx-sub-form/src/lib/ngx-sub-form-utils.ts
@@ -2,9 +2,9 @@ import { AbstractControl, ControlValueAccessor, NG_VALUE_ACCESSOR, NG_VALIDATORS
 import { InjectionToken, Type, forwardRef } from '@angular/core';
 import { SUB_FORM_COMPONENT_TOKEN } from './ngx-sub-form-tokens';
 
-export type Controls<T> = { [K in keyof T]: AbstractControl };
+export type Controls<T> = { [K in keyof T]-?: AbstractControl };
 
-export type ControlsNames<T> = { [K in keyof T]: K };
+export type ControlsNames<T> = { [K in keyof T]-?: K };
 
 export function getControlsNames<T extends { [key: string]: any }>(controls: Controls<T>): ControlsNames<T> {
   return Object.keys(controls).reduce(


### PR DESCRIPTION
When implementing a form for a given interface even if values are optional we want to show them in the form. If we don't then it's easy to use "Omit". But in most cases we do and this will prevent us from forgetting about them.