### PR TITLE
fix(lib): initialize form value considering custom transformation

### DIFF
--- a/projects/ngx-sub-form/src/lib/ngx-sub-form.component.ts
+++ b/projects/ngx-sub-form/src/lib/ngx-sub-form.component.ts
@@ -85,7 +85,7 @@ export abstract class NgxSubFormComponent<ControlInterface, FormInterface = Cont
     this.onChange = fn;
 
     // this is required to correctly initialize the form value
-    this.onChange(this.formGroup.value);
+    this.onChange(this.transformFromFormGroup(this.formGroup.value));
 
     this.subscription = this.formGroup.valueChanges
       .pipe(


### PR DESCRIPTION
This fix is meant to correctly set the initial value of the `FormGroup`, considering a possible custom transformation, during the component registration phase.

Closes #12 