### PR TITLE
feat(lib): add onFormUpdate hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,10 @@ export class VehicleProductComponent extends NgxSubFormRemapComponent<OneVehicle
 
 Our "incoming" object is of type `OneVehicle` but into that component we treat it as a `OneVehicleForm` to split the vehicule (either a `speeder` or `spaceship`) in 2 **separated** properties.
 
+### Helpers
+
+- `onFormUpdate` hook: Allows you to react whenever the form is being modified. Behind the scenes it is just subscribing to `formGroup.valueChanges` and calling the method but from a consumer point of view, you will not have to deal with anything asynchronous nor have to worry about subscriptions and memory leaks
+
 ## Be aware of
 
 There's currently a weird behavior ~~[issue (?)](https://github.com/angular/angular/issues/18004)~~ when checking for form validity.  

--- a/projects/ngx-sub-form/src/lib/ngx-sub-form-utils.ts
+++ b/projects/ngx-sub-form/src/lib/ngx-sub-form-utils.ts
@@ -1,12 +1,22 @@
 import { AbstractControl, ControlValueAccessor, NG_VALUE_ACCESSOR, NG_VALIDATORS } from '@angular/forms';
 import { InjectionToken, Type, forwardRef } from '@angular/core';
 import { SUB_FORM_COMPONENT_TOKEN } from './ngx-sub-form-tokens';
+import { NgxSubFormComponent, NgxSubFormRemapComponent } from './ngx-sub-form.component';
 
 export type Controls<T> = { [K in keyof T]-?: AbstractControl };
 
 export type ControlsNames<T> = { [K in keyof T]-?: K };
 
 export type ControlMap<T, V> = { [K in keyof T]-?: V };
+
+export interface FormChange<T> {
+  isInitialValue: boolean;
+  formValue: T;
+}
+
+export interface FormRemapChange<T, V> extends FormChange<T> {
+  formRemapValue: V | null;
+}
 
 export function subformComponentProviders(
   component: any,
@@ -31,4 +41,14 @@ export function subformComponentProviders(
       useExisting: forwardRef(() => component),
     },
   ];
+}
+
+export function isNgxSubFormRemapComponent(
+  currInstance: NgxSubFormComponent<any>,
+): currInstance is NgxSubFormRemapComponent<any, any> {
+  if (currInstance instanceof NgxSubFormRemapComponent) {
+    return true;
+  }
+
+  return false;
 }


### PR DESCRIPTION
It is now possible to use the onFormUpdate hook to react to form changes. The main purpose of that hook is for the consumer to not have to deal with observables.

BREAKING CHANGE: If you were previously subscribing to `formGroup.valueChanges` it'd only emit when local changes were made to the form. From now on, if the form is patched/set from the parent, the child component listening to those changes will also emit.

This closes cloudnc/ngx-sub-form#34