### PR TITLE
feat(lib): add onFormUpdate hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,10 @@ export class VehicleProductComponent extends NgxSubFormRemapComponent<OneVehicle
 
 Our "incoming" object is of type `OneVehicle` but into that component we treat it as a `OneVehicleForm` to split the vehicule (either a `speeder` or `spaceship`) in 2 **separated** properties.
 
+### Helpers
+
+- `onFormUpdate` hook: Allows you to react whenever the form is being modified. Instead of subscribing to `this.formGroup.valueChanges` or `this.formControls.someProp.valueChanges` you will not have to deal with anything asynchronous nor have to worry about subscriptions and memory leaks. Just implement the method `onFormUpdate(formUpdate: FormUpdate<FormInterface>): void` and if you need to know which property changed do a check like the following: `if (formUpdate.yourProperty) {}`. Be aware that this method will be called only when there are either local changes to the form or changes coming from subforms. If the parent `setValue` or `patchValue` this method won't be triggered
+
 ## Be aware of
 
 There's currently a weird behavior ~~[issue (?)](https://github.com/angular/angular/issues/18004)~~ when checking for form validity.  

--- a/projects/ngx-sub-form/src/helpers/utils.ts
+++ b/projects/ngx-sub-form/src/helpers/utils.ts
@@ -1,0 +1,12 @@
+// nothing in that file should be referenced into the `public_api.ts` file!
+// those are internal helpers only
+
+export const keyValuePairToObj = <T extends { [key: string]: any }>(x: { key: any; value: any }[]): T =>
+  x.reduce(
+    (acc, { key, value }) => {
+      acc[key] = value;
+
+      return acc;
+    },
+    {} as T,
+  );

--- a/projects/ngx-sub-form/src/lib/ngx-sub-form-utils.ts
+++ b/projects/ngx-sub-form/src/lib/ngx-sub-form-utils.ts
@@ -8,6 +8,8 @@ export type ControlsNames<T> = { [K in keyof T]-?: K };
 
 export type ControlMap<T, V> = { [K in keyof T]-?: V };
 
+export type FormUpdate<FormInterface> = { [FormControlInterface in keyof FormInterface]?: true };
+
 export function subformComponentProviders(
   component: any,
 ): {

--- a/projects/ngx-sub-form/src/lib/ngx-sub-form.component.spec.ts
+++ b/projects/ngx-sub-form/src/lib/ngx-sub-form.component.spec.ts
@@ -229,19 +229,20 @@ describe(`NgxSubFormComponent`, () => {
       }, 0);
     });
 
-    it(`should call onChange and onTouched callback on next tick every time the form value changes`, (done: () => void) => {
+    it(`should call onChange and onTouched callback on next tick every time one of the form value changes`, (done: () => void) => {
       const onTouchedSpy = jasmine.createSpy('onTouchedSpy');
       const onChangeSpy = jasmine.createSpy('onChangeSpy');
 
       subComponent.registerOnTouched(onTouchedSpy);
       subComponent.registerOnChange(onChangeSpy);
 
-      subComponent.formGroup.setValue(getDefaultValues());
+      subComponent.formGroupControls.color.setValue('red');
 
       setTimeout(() => {
         expect(onTouchedSpy).toHaveBeenCalledTimes(1);
         expect(onChangeSpy).toHaveBeenCalledTimes(2);
         expect(onChangeSpy).toHaveBeenCalledWith(getDefaultValues());
+        expect(onChangeSpy).toHaveBeenCalledWith({ ...getDefaultValues(), color: 'red' });
 
         done();
       }, 0);
@@ -268,6 +269,42 @@ describe(`NgxSubFormComponent`, () => {
       subComponent.setDisabledState(false);
       expect(spyDisable).not.toHaveBeenCalled();
       expect(spyEnable).toHaveBeenCalled();
+    });
+  });
+
+  describe(`onFormUpdate`, () => {
+    it(`should not call onFormUpdate when patched by the parent (through "writeValue")`, (done: () => void) => {
+      const spyOnFormUpdate = jasmine.createSpy();
+      subComponent.onFormUpdate = spyOnFormUpdate;
+      subComponent.registerOnChange(() => {});
+
+      setTimeout(() => {
+        spyOnFormUpdate.calls.reset();
+
+        subComponent.writeValue({ ...subComponent.formGroupValues, color: 'red' });
+
+        setTimeout(() => {
+          expect(spyOnFormUpdate).not.toHaveBeenCalled();
+
+          done();
+        }, 0);
+      }, 0);
+    });
+
+    it(`should call onFormUpdate everytime the form changes (local changes)`, (done: () => void) => {
+      const spyOnFormUpdate = jasmine.createSpy();
+      subComponent.onFormUpdate = spyOnFormUpdate;
+      subComponent.registerOnChange(() => {});
+
+      subComponent.formGroupControls.color.setValue(`red`);
+
+      setTimeout(() => {
+        expect(spyOnFormUpdate).toHaveBeenCalledWith({
+          color: true,
+        });
+
+        done();
+      }, 0);
     });
   });
 });


### PR DESCRIPTION
It is now possible to use the onFormUpdate hook to react to form changes. The main purpose of that hook is for the consumer to not have to deal with observables.

This closes #34