### PR TITLE
refactor(oneOf validator): Refactor oneOf validator 

### DIFF
--- a/projects/ngx-sub-form/src/lib/one-of.validator.ts
+++ b/projects/ngx-sub-form/src/lib/one-of.validator.ts
@@ -1,0 +1,36 @@
+import { AbstractControl } from '@angular/forms';
+import { TypedFormGroup, TypedValidatorFn } from './ngx-sub-form.types';
+import {
+  isNullOrUndefined,
+  OneOfValidatorRequiresMoreThanOneFieldError,
+  OneOfValidatorUnknownFieldError,
+} from './ngx-sub-form-utils';
+
+export namespace NgxSubFormValidators {
+
+  export function oneOf<FormInterface>(keysArray: Array<keyof FormInterface>, errorKey = 'oneOf'): TypedValidatorFn<FormInterface> {
+    if (!keysArray || keysArray.length < 2) {
+      throw new OneOfValidatorRequiresMoreThanOneFieldError();
+    }
+
+    return (formGroup: TypedFormGroup<FormInterface>) => {
+
+      const notNullKeys: Array<keyof FormInterface> = keysArray.filter((key) => {
+        const control: AbstractControl | null = formGroup.get(key as string);
+
+        if (!control) {
+          throw new OneOfValidatorUnknownFieldError(key as string);
+        }
+
+        return !isNullOrUndefined(control.value);
+      });
+
+      if (notNullKeys.length === 1) {
+        return null;
+      }
+
+      return { [errorKey]: notNullKeys };
+    }
+  }
+
+}


### PR DESCRIPTION
... to be less tied to ngx-subform implementation. Restructured errors for oneOf behaviour to be
 explicitly named rather than implicit by array index location