### PR TITLE
fix(lib): emitted value should always reflect the latest state of the form

### DIFF
--- a/projects/ngx-sub-form/src/lib/ngx-sub-form.component.spec.ts
+++ b/projects/ngx-sub-form/src/lib/ngx-sub-form.component.spec.ts
@@ -270,7 +270,7 @@ describe(`NgxSubFormComponent`, () => {
       setTimeout(() => {
         expect(onTouchedSpy).toHaveBeenCalledTimes(1);
         expect(onChangeSpy).toHaveBeenCalledTimes(2);
-        expect(onChangeSpy).toHaveBeenCalledWith(getDefaultValues());
+        expect(onChangeSpy).toHaveBeenCalledWith({ ...getDefaultValues(), color: 'red' });
         expect(onChangeSpy).toHaveBeenCalledWith({ ...getDefaultValues(), color: 'red' });
 
         done();
@@ -296,6 +296,36 @@ describe(`NgxSubFormComponent`, () => {
 
         done();
       }, DEBOUNCE_TIMING + 100);
+    });
+
+    it(`should always have the latest value of the form when it changes`, (done: () => void) => {
+      const onTouchedSpy = jasmine.createSpy('onTouchedSpy');
+      const onChangeSpy = jasmine.createSpy('onChangeSpy');
+
+      subComponent.registerOnTouched(onTouchedSpy);
+      subComponent.registerOnChange(onChangeSpy);
+
+      const crewMemberCount: number = getDefaultValues().crewMemberCount || 0;
+
+      setTimeout(() => {
+        expect(onChangeSpy.calls.count()).toEqual(1);
+        expect(onChangeSpy.calls.argsFor(0)).toEqual([getDefaultValues()]);
+
+        subComponent.formGroupControls.crewMemberCount.setValue(crewMemberCount + 1);
+        subComponent.formGroupControls.crewMemberCount.setValue(crewMemberCount + 2);
+
+        setTimeout(() => {
+          expect(onChangeSpy.calls.count()).toEqual(3);
+          expect(onChangeSpy.calls.argsFor(1)).toEqual([
+            { ...getDefaultValues(), crewMemberCount: crewMemberCount + 2 },
+          ]);
+          expect(onChangeSpy.calls.argsFor(2)).toEqual([
+            { ...getDefaultValues(), crewMemberCount: crewMemberCount + 2 },
+          ]);
+
+          done();
+        }, 0);
+      }, 0);
     });
   });
 

--- a/projects/ngx-sub-form/src/lib/ngx-sub-form.component.ts
+++ b/projects/ngx-sub-form/src/lib/ngx-sub-form.component.ts
@@ -318,14 +318,23 @@ export abstract class NgxSubFormComponent<ControlInterface, FormInterface = Cont
         filter(() => !!this.formGroup),
         // detect which stream emitted last
         withLatestFrom(lastKeyEmitted$),
-        map(([changes, keyLastEmit], index) => {
+        map(([_, keyLastEmit], index) => {
           if (index > 0 && this.onTouched) {
             this.onTouched();
           }
 
           if (index > 0 || (index === 0 && this.emitInitialValueOnInit)) {
             if (this.onChange) {
-              this.onChange(this.transformFromFormGroup(changes));
+              this.onChange(
+                this.transformFromFormGroup(
+                  // do not use the changes passed by `this.formGroup.valueChanges` here
+                  // as we've got a delay(0) above, on the next tick the form data might
+                  // be outdated and might result into an inconsistent state where a form
+                  // state is valid (base on latest value) but the previous value
+                  // (the one passed by `this.formGroup.valueChanges` would be the previous one)
+                  this.formGroup.value,
+                ),
+              );
             }
 
             const formUpdate: FormUpdate<FormInterface> = {};


### PR DESCRIPTION
This closes cloudnc/ngx-sub-form#98