### PR TITLE
[DO NOT MERGE YET] fix(lib): access class props from get form controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Really small bundle (< 15kb) and no module to setup. Pick the class you need and
 
 Built for **all your different forms** (tiny to extra large!), this library will deal with all the boilerplate required to use a [`ControlValueAccessor`](https://blog.angularindepth.com/never-again-be-confused-when-implementing-controlvalueaccessor-in-angular-forms-93b9eee9ee83) internally and let you manage your most complex forms in a fast and easy way.
 
-From creating a small custom input, to breaking down a form into multiple sub components, `ngx-sub-form` will give you a lot of functionalities like better type safety to survive futur refactors (from both `TS` and `HTML`), remapping external data to the shape you need within your form, access nested errors and many more. It'll also save you from passing a `FormGroup` to an `@Input` :pray:.
+From creating a small custom input, to breaking down a form into multiple sub components, `ngx-sub-form` will give you a lot of functionalities like better type safety to survive future refactors (from both `TS` and `HTML`), remapping external data to the shape you need within your form, access nested errors and many more. It'll also save you from passing a `FormGroup` to an `@Input` :pray:.
 
 It also works particularly well with polymorphic data structures.
 
@@ -122,7 +122,7 @@ export interface OneListingForm {
 })
 export class ListingComponent extends NgxAutomaticRootFormComponent<OneListing, OneListingForm> {
   // as we're renaming the input, it'd be impossible for ngx-sub-form to guess
-  // the name of your input to then check within the `ngOnChanges` hook wheter
+  // the name of your input to then check within the `ngOnChanges` hook whether
   // it has been updated or not
   // another solution would be to ask you to use a setter and call a hook but
   // this is too verbose, that's why we created a decorator `@DataInput`
@@ -202,9 +202,9 @@ _Note the presence of disabled, this is an optional input provided by both `NgxR
 Differences between:
 
 - `NgxRootFormComponent`: Will never emit the form value automatically when it changes, to emit the value you'll have to call the method `manualSave` when needed
-- `NgxAutomaticRootFormComponent`: Will emit the form value as soon as there's a change. It's possible to customize the emission rate by overidding the `handleEmissionRate` method
+- `NgxAutomaticRootFormComponent`: Will emit the form value as soon as there's a change. It's possible to customize the emission rate by overriding the `handleEmissionRate` method
 
-The method `handleEmissionRate` is available accross **all** the classes that `ngx-sub-form` offers. It takes an observable as input and expect another observable as output. One common case is to simply [`debounce`](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-debounce) the emission. If that's what you want to do, instead of manipulating the observable chain yourself you can just do:
+The method `handleEmissionRate` is available across **all** the classes that `ngx-sub-form` offers. It takes an observable as input and expect another observable as output. One common case is to simply [`debounce`](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-debounce) the emission. If that's what you want to do, instead of manipulating the observable chain yourself you can just do:
 
 ```ts
 // src/readme/handle-emission-rate.ts#L6-L9
@@ -258,7 +258,7 @@ _Simplified from the original example into src folder to keep the example as min
 
 ### Remapping Data
 
-It is a frequent pattern to have the data that you're trying to modify in a format that is incovenient to the angular forms structural constraints. For this reason, `ngx-form-component` offers a separate class `NgxSubFormRemapComponent`
+It is a frequent pattern to have the data that you're trying to modify in a format that is inconvenient to the angular forms structural constraints. For this reason, `ngx-form-component` offers a separate class `NgxSubFormRemapComponent`
 which will require you to define two interfaces:
 
 - One to model the data going into the form
@@ -533,7 +533,7 @@ export class CrewMemberComponent extends NgxSubFormComponent<CrewMember> {
 
 **Properties**
 
-- `emitNullOnDestroy`: By default is set to `true` for `NgxSubFormComponent`, `NgxSubFormRemapComponent` and to `false` for `NgxRootFormComponent` and `NgxAutomaticRootFormComponent`. When set to `true`, if the sub form component is being destroyed, it will emit one last value: `null`. It might be useful to set it to `false` for e.g. when you've got a form accross multiple tabs and once a part of the form is filled you want to destroy it
+- `emitNullOnDestroy`: By default is set to `true` for `NgxSubFormComponent`, `NgxSubFormRemapComponent` and to `false` for `NgxRootFormComponent` and `NgxAutomaticRootFormComponent`. When set to `true`, if the sub form component is being destroyed, it will emit one last value: `null`. It might be useful to set it to `false` for e.g. when you've got a form across multiple tabs and once a part of the form is filled you want to destroy it
 - `emitInitialValueOnInit`: By default is set to `true` for `NgxSubFormComponent`, `NgxSubFormRemapComponent` and to `false` for `NgxRootFormComponent` and `NgxAutomaticRootFormComponent`. When set to `true`, the sub form component will emit the first value straight away (default one unless the component above as a value already set on the `formControl`)
 
 **Hooks**

--- a/projects/ngx-sub-form/src/lib/ngx-root-form.component.ts
+++ b/projects/ngx-sub-form/src/lib/ngx-root-form.component.ts
@@ -34,6 +34,8 @@ export abstract class NgxRootFormComponent<ControlInterface, FormInterface = Con
   protected dataValue: ControlInterface | null = null;
 
   public ngOnInit(): void {
+    super.ngOnInit();
+
     // we need to manually call registerOnChange because that function
     // handles most of the logic from NgxSubForm and when it's called
     // as a ControlValueAccessor that function is called by Angular itself

--- a/projects/ngx-sub-form/src/lib/ngx-sub-form.component.spec.ts
+++ b/projects/ngx-sub-form/src/lib/ngx-sub-form.component.spec.ts
@@ -77,6 +77,7 @@ class SubComponentWithDefaultValues extends NgxSubFormComponent<Vehicle> {
 describe(`Common`, () => {
   it(`should call formGroup.updateValueAndValidity only if formGroup is defined`, (done: () => void) => {
     const subComponent: SubComponent = new SubComponent();
+    subComponent.ngOnInit();
 
     const formGroupSpy = spyOn(subComponent.formGroup, 'updateValueAndValidity');
 
@@ -96,8 +97,11 @@ describe(`NgxSubFormComponent`, () => {
 
   beforeEach((done: () => void) => {
     subComponent = new SubComponent();
+    subComponent.ngOnInit();
     debouncedSubComponent = new DebouncedSubComponent();
+    debouncedSubComponent.ngOnInit();
     subComponentWithDefaultValues = new SubComponentWithDefaultValues();
+    subComponentWithDefaultValues.ngOnInit();
 
     // we have to call `updateValueAndValidity` within the constructor in an async way
     // and here we need to wait for it to run
@@ -512,6 +516,7 @@ describe(`NgxSubFormComponent`, () => {
 
     beforeEach((done: () => void) => {
       validatedSubComponent = new ValidatedSubComponent();
+      validatedSubComponent.ngOnInit();
 
       // we have to call `updateValueAndValidity` within the constructor in an async way
       // and here we need to wait for it to run
@@ -580,6 +585,7 @@ describe(`NgxSubFormRemapComponent`, () => {
 
   beforeEach((done: () => void) => {
     subRemapComponent = new SubRemapComponent();
+    subRemapComponent.ngOnInit();
 
     // we have to call `updateValueAndValidity` within the constructor in an async way
     // and here we need to wait for it to run
@@ -685,6 +691,7 @@ describe(`SubArrayComponent`, () => {
 
   beforeEach((done: () => void) => {
     subArrayComponent = new SubArrayComponent();
+    subArrayComponent.ngOnInit();
 
     // we have to call `updateValueAndValidity` within the constructor in an async way
     // and here we need to wait for it to run

--- a/src/readme/listing.component.ts
+++ b/src/readme/listing.component.ts
@@ -29,7 +29,7 @@ export interface OneListingForm {
 })
 export class ListingComponent extends NgxAutomaticRootFormComponent<OneListing, OneListingForm> {
   // as we're renaming the input, it'd be impossible for ngx-sub-form to guess
-  // the name of your input to then check within the `ngOnChanges` hook wheter
+  // the name of your input to then check within the `ngOnChanges` hook whether
   // it has been updated or not
   // another solution would be to ask you to use a setter and call a hook but
   // this is too verbose, that's why we created a decorator `@DataInput`


### PR DESCRIPTION
@zakhenry this PR contains a **breaking change**.

Even though it's technically [written in the README](https://github.com/cloudnc/ngx-sub-form/blob/1956d258b705bd4e489d0f3a46419c1bc135d8d3/README.md#angular-hooks) that ngx-sub-form uses `ngOnInit` hook and therefore it's the consumer responsibility to call `super.ngOnInit()`, I don't think it'd be fair to publish that as a non breaking change because people were simply not able to call `super.ngOnInit()` on `NgxSubFormComponent` nor `NgxSubFormRemapComponent` so far.

For the context, please have a look on https://github.com/cloudnc/ngx-sub-form/issues/82 where I've added some details.