### PR TITLE
fix: peer dependencies for tsdef and ngx-observable-lifecycle

### DIFF
--- a/projects/ngx-sub-form/package.json
+++ b/projects/ngx-sub-form/package.json
@@ -10,8 +10,9 @@
     "@angular/common": ">= 10 < 13",
     "@angular/core": ">= 10 < 13",
     "@angular/forms": ">= 10 < 13",
-    "ngx-observable-lifecycle": "^2.1.4",
-    "rxjs": "^6.5.4 || ^7.4.0"
+    "ngx-observable-lifecycle": "^2.2.1",
+    "rxjs": "^6.5.4 || ^7.4.0",
+    "tsdef": "0.0.13"
   },
   "keywords": [
     "Angular",


### PR DESCRIPTION
This fixes an issue reported to me by someone:

```
./node_modules/ngx-sub-form/fesm2020/ngx-sub-form.mjs:7:0-66 - Error: Module not found: Error: Can't resolve 'ngx-observable-lifecycle' in 'C:\[.......]\node_modules\ngx-sub-form\fesm2020'

Error: node_modules/ngx-sub-form/lib/ngx-sub-form.types.d.ts:3:25 - error TS2307: Cannot find module 'tsdef' or its corresponding type declarations.
```