### PR TITLE
Fixed to propagate formarray validation status

### DIFF
--- a/cypress/e2e/app.cy.ts
+++ b/cypress/e2e/app.cy.ts
@@ -174,6 +174,9 @@ context(`EJawa demo`, () => {
                 },
                 crewMembers: {
                   required: true,
+                  crewMembers: {
+                    minimumCrewMemberCount: 2
+                  },
                 },
                 wingCount: {
                   required: true,
@@ -194,80 +197,42 @@ context(`EJawa demo`, () => {
 
         DOM.form.elements.vehicleForm.addCrewMemberButton.click();
 
-        if (id === 'old') {
-          DOM.form.errors.should($el => {
-            expect(extractErrors($el)).to.eql({
-              vehicleProduct: {
-                spaceship: {
-                  color: {
-                    required: true,
-                  },
-                  crewMembers: {
-                    crewMembers: [
-                      {
-                        firstName: {
-                          required: true,
-                        },
-                        lastName: {
-                          required: true,
-                        },
-                      },
-                    ],
-                  },
-                  wingCount: {
-                    required: true,
-                  },
+        DOM.form.errors.should($el => {
+          expect(extractErrors($el)).to.eql({
+            vehicleProduct: {
+              spaceship: {
+                color: {
+                  required: true,
                 },
-              },
-              title: {
-                required: true,
-              },
-              imageUrl: {
-                required: true,
-              },
-              price: {
-                required: true,
-              },
-            });
-          });
-        } else {
-          DOM.form.errors.should($el => {
-            expect(extractErrors($el)).to.eql({
-              vehicleProduct: {
-                spaceship: {
-                  color: {
-                    required: true,
-                  },
+                crewMembers: {
                   crewMembers: {
-                    crewMembers: {
-                      minimumCrewMemberCount: 2,
-                      0: {
-                        firstName: {
-                          required: true,
-                        },
-                        lastName: {
-                          required: true,
-                        },
+                    minimumCrewMemberCount: 2,
+                    0: {
+                      firstName: {
+                        required: true,
+                      },
+                      lastName: {
+                        required: true,
                       },
                     },
                   },
-                  wingCount: {
-                    required: true,
-                  },
+                },
+                wingCount: {
+                  required: true,
                 },
               },
-              title: {
-                required: true,
-              },
-              imageUrl: {
-                required: true,
-              },
-              price: {
-                required: true,
-              },
-            });
+            },
+            title: {
+              required: true,
+            },
+            imageUrl: {
+              required: true,
+            },
+            price: {
+              required: true,
+            },
           });
-        }
+        });
 
         DOM.form.elements.selectListingTypeByType(ListingType.DROID);
 

--- a/projects/ngx-sub-form/src/lib/ngx-sub-form.ts
+++ b/projects/ngx-sub-form/src/lib/ngx-sub-form.ts
@@ -239,7 +239,7 @@ export function createForm<ControlInterface, FormInterface>(
     ),
     updateValue$: updateValueAndValidity$.pipe(
       tap(() => {
-        formGroup.updateValueAndValidity({ emitEvent: false });
+        formGroup.updateValueAndValidity({ emitEvent: true });
       }),
     ),
     bindTouched$: combineLatest([componentHooks.registerOnTouched$, options.touched$ ?? EMPTY]).pipe(

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,9 +1,13 @@
-import { NgModule } from '@angular/core';
+import { registerLocaleData } from '@angular/common';
+import { LOCALE_ID, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule } from '@angular/router';
 import { AppComponent } from './app.component';
 import { SharedModule } from './shared/shared.module';
+import localeDe from '@angular/common/locales/de';
+
+registerLocaleData(localeDe, 'de');
 
 @NgModule({
   declarations: [AppComponent],
@@ -25,7 +29,7 @@ import { SharedModule } from './shared/shared.module';
     ),
     SharedModule,
   ],
-  providers: [],
+  providers: [{provide: LOCALE_ID, useValue: 'de' }],
   bootstrap: [AppComponent],
 })
 export class AppModule {}


### PR DESCRIPTION
I fixed the issue to propagate the formarray validation within the new implementation and also within the old implementation for backwards compatibility (so we should merge this into master and version 5.3.x). I changed the e2e test to expect the formarray validation and removed the test part for the old implementation, because the behavior is now the same. I set the locale id to DE, maybe use another locale. In german the number pipe displays the price with dots like 45.000.000. In en-US its displayed with comma like 45,000,000. But the e2e tests expects a number with dots. So to have a constant e2e run on every system we should choice a locale which prints numbers with dots or change the e2e expectation to compare against strings with commas.